### PR TITLE
(Fix #179) Fix alignment for lambdas and blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is described in [Contributing notes](CONTRIBUTING.md#changelog-entry-
 * [#32](https://github.com/datarockets/ruby-style/issues/32) Enable back `Style/FrozenStringLiteralComment` cop. ([@r.dubrovsky][])
 * [#176](https://github.com/datarockets/ruby-style/issues/176) Fix hash alignment via changing `Layout/HashAlignment` cop. ([@r.dubrovsky][])
 * [#258](https://github.com/datarockets/ruby-style/issues/258) Setup `EnforcedStyle` for `Layout/FirstArrayElementIndentation` cop. ([@r.dubrovsky][])
+* [#179](https://github.com/datarockets/ruby-style/issues/179) Setup `EnforcedStyleAlignWith` rule for `Layout/BlockAlignment` cop. ([@r.dubrovsky][])
 
 ### Fixed
 

--- a/config/base.yml
+++ b/config/base.yml
@@ -25,6 +25,9 @@ Layout/ArrayAlignmentExtended:
     - with_fixed_indentation
   IndentationWidth: ~
 
+Layout/BlockAlignment:
+  EnforcedStyleAlignWith: start_of_block
+
 Layout/CaseIndentation:
   EnforcedStyle: end
 

--- a/spec/rubocop_examples/hash_styles.rb
+++ b/spec/rubocop_examples/hash_styles.rb
@@ -2,6 +2,15 @@
 
 module RubocopExamples
   class HashStyles
+    def initialize
+      # issue: https://github.com/datarockets/ruby-style/issues/179
+      @test = {
+        test: lambda do |i|
+          i
+        end,
+      }
+    end
+
     # issue: https://github.com/datarockets/ruby-style/issues/176
     def test1
       MemberResponse.create!({


### PR DESCRIPTION
This PR fixes issue: https://github.com/datarockets/ruby-style/issues/179

Before you submit a pull request, please make sure you have to follow:

- [ ] read and know items from the [Contributing Guide](https://github.com/datarockets/datarockets-style/blob/master/CONTRIBUTING.md#pull-requests)
- [ ] add a description of the problem you're trying to solve (short summary from related issue)
- [ ] verified that cops are ordered by alphabet
- [ ] add a note to the style guide docs (if it needs)
- [ ] add a note to the changelog file
- [ ] the commit message contains the number of the related issue (if it presents)
  and word `Fix` if this PR closes related issue
- [ ] squash all commits before submitting to review
